### PR TITLE
adding ability to import  public key resource

### DIFF
--- a/form3/resource_credential_public_key_test.go
+++ b/form3/resource_credential_public_key_test.go
@@ -71,6 +71,31 @@ func TestAccCredentialPublicKey_singleKey(t *testing.T) {
 	})
 }
 
+func TestAccCredentialPublicKey_import(t *testing.T) {
+	log.SetOutput(os.Stdout)
+	organisationID := os.Getenv("FORM3_ORGANISATION_ID")
+	publicKeyID := uuid.NewV4().String()
+	userID := uuid.NewV4().String()
+	roleID := uuid.NewV4().String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCredentialPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testForm3CredentialPublicKeyConfigSingle, organisationID, roleID, organisationID, userID, publicKeyID),
+			},
+			{
+				ResourceName:      "form3_credential_public_key.test_public_key_single",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/%s", userID, publicKeyID),
+			},
+		},
+	})
+}
+
 func testAccCheckCredentialPublicKeyDestroy(state *terraform.State) error {
 	client := testAccProvider.Meta().(*form3.AuthenticatedClient)
 

--- a/form3/resource_credential_publickey.go
+++ b/form3/resource_credential_publickey.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform/helper/schema"
 	"log"
+	"strings"
 )
 
 func resourceForm3CredentialPublicKey() *schema.Resource {
@@ -16,6 +17,9 @@ func resourceForm3CredentialPublicKey() *schema.Resource {
 		Create: resourceCredentialPublicKeyCreate,
 		Read:   resourceCredentialPublicKeyRead,
 		Delete: resourceCredentialPublicKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCredentialPublicKeyImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"user_id": &schema.Schema{
@@ -40,6 +44,16 @@ func resourceForm3CredentialPublicKey() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceCredentialPublicKeyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("public key import id must be in form '<userId>/<publicKeyId>'")
+	}
+	d.SetId(parts[1])
+	d.Set("user_id", parts[0])
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceCredentialPublicKeyCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Import requires two values in the key - `<userId>/<publicKeyId>` - to read key from api both `userId` and `publicKeyId` is needed.

Acceptance test uses standard HashiCorp testing process that creates new state internally and imports resource to it and then runs a compare verifying if its correct.