### PR TITLE
WIP Allow reuse of existing keys in certificate api

### DIFF
--- a/form3/resource_certificate_test.go
+++ b/form3/resource_certificate_test.go
@@ -314,8 +314,8 @@ func TestAccKey_reuseExistingKey(t *testing.T) {
 		CheckDestroy: testAccCheckKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:            fmt.Sprintf(testForm3KeyConfigReusingExistingKey, organisationId, keyId),
-				ResourceName:      "form3_key.test_key",
+				Config:       fmt.Sprintf(testForm3KeyConfigReusingExistingKey, organisationId, keyId),
+				ResourceName: "form3_key.test_key",
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists("form3_key.test_key", &response),
 					resource.TestCheckResourceAttr("form3_key.test_key", "organisation_id", organisationId),
@@ -323,9 +323,9 @@ func TestAccKey_reuseExistingKey(t *testing.T) {
 					resource.TestCheckResourceAttr("form3_key.test_key", "subject", "CN=Terraform-test-existing"),
 					resource.TestCheckResourceAttr("form3_key.test_key", "private_key", "existing-key-101"),
 					resource.TestCheckResourceAttr("form3_key.test_key", "public_key", "existing-key-103"),
-					),
+				),
 				ExpectNonEmptyPlan: false,
-				ExpectError: regexp.MustCompile("errors during apply: failed to create Key: ErrorCode:(.)* Message: Unhandled error"),
+				ExpectError:        regexp.MustCompile("errors during apply: failed to create Key: ErrorCode:(.)* Message: Unhandled error"),
 			},
 		},
 	})

--- a/form3/resource_key.go
+++ b/form3/resource_key.go
@@ -45,12 +45,14 @@ func resourceForm3Key() *schema.Resource {
 			"private_key": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 				Required: false,
 				ForceNew: true,
 			},
 			"public_key": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 				Required: false,
 				ForceNew: true,
 			},
@@ -192,6 +194,14 @@ func createKeyFromResourceData(d *schema.ResourceData) (*models.Key, error) {
 
 	if attr, ok := d.GetOk("curve"); ok {
 		certificateRequest.Attributes.Curve = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("private_key"); ok {
+		certificateRequest.Attributes.PrivateKey = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("public_key"); ok {
+		certificateRequest.Attributes.PublicKey = attr.(string)
 	}
 
 	return certificateRequest, nil

--- a/form3/resource_subscription.go
+++ b/form3/resource_subscription.go
@@ -118,7 +118,7 @@ func resourceSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*form3.AuthenticatedClient)
 	subscriptionFromResource, err := createSubscriptionFromResourceDataWithVersion(d, client)
 	if err != nil {
-		return fmt.Errorf("error updating subscription: %s", form3.JsonErrorPrettyPrint(err))
+		return fmt.Errorf("error fetching subscription to update: %s", form3.JsonErrorPrettyPrint(err))
 	}
 
 	_, err = client.NotificationClient.Subscriptions.PatchSubscriptionsID(subscriptions.NewPatchSubscriptionsIDParams().
@@ -126,7 +126,7 @@ func resourceSubscriptionUpdate(d *schema.ResourceData, meta interface{}) error 
 		WithSubscriptionUpdateRequest(&models.SubscriptionCreation{Data: subscriptionFromResource}))
 
 	if err != nil {
-		return fmt.Errorf("error updating subscription: %s", form3.JsonErrorPrettyPrint(err))
+		return fmt.Errorf("error updating subscription '%s': %s", subscriptionFromResource.ID, form3.JsonErrorPrettyPrint(err))
 	}
 
 	return nil


### PR DESCRIPTION
Allow keys to be recycled if they have been decommissioned, by providing an optional `public_key` and `private_key` value.

If both values are set, we can mandate the value of the `private_key` to be stored in the HSM.

If only the `public_key` value is set an existing `private_key` kept within the HSM can be reused (by design, it is not  possible to extract `private_keys` from the HSM so if we only know the `public_key` from logs then this is the behaviour we need).

If neither value is set then the existing functionality will be preserved. For this reason the values are marked as both `Computed` and `Optional` as this is appropriate per the terraform docs.