### PR TITLE
Remove APPROVE and REJECT ACEs

### DIFF
--- a/examples/ace/all/main.tf
+++ b/examples/ace/all/main.tf
@@ -10,60 +10,12 @@ resource "form3_ace" "ace-edit" {
   }
 }
 
-resource "form3_ace" "ace-edit-approve" {
-  ace_id          = "${uuid()}"
-  role_id         = "${var.role_id}"
-  organisation_id = "${var.organisation_id}"
-  record_type     = "${element(var.records, count.index)}"
-  action          = "EDIT_APPROVE"
-  count           = "${length(var.records)}"
-  lifecycle {
-    ignore_changes = ["ace_id"]
-  }
-}
-
 resource "form3_ace" "ace-delete" {
   ace_id          = "${uuid()}"
   role_id         = "${var.role_id}"
   organisation_id = "${var.organisation_id}"
   record_type     = "${element(var.records, count.index)}"
   action          = "DELETE"
-  count           = "${length(var.records)}"
-  lifecycle {
-    ignore_changes = ["ace_id"]
-  }
-}
-
-resource "form3_ace" "ace-delete-approve" {
-  ace_id          = "${uuid()}"
-  role_id         = "${var.role_id}"
-  organisation_id = "${var.organisation_id}"
-  record_type     = "${element(var.records, count.index)}"
-  action          = "DELETE_APPROVE"
-  count           = "${length(var.records)}"
-  lifecycle {
-    ignore_changes = ["ace_id"]
-  }
-}
-
-resource "form3_ace" "ace-reject" {
-  ace_id          = "${uuid()}"
-  role_id         = "${var.role_id}"
-  organisation_id = "${var.organisation_id}"
-  record_type     = "${element(var.records, count.index)}"
-  action          = "REJECT"
-  count           = "${length(var.records)}"
-  lifecycle {
-    ignore_changes = ["ace_id"]
-  }
-}
-
-resource "form3_ace" "ace-reject-approve" {
-  ace_id          = "${uuid()}"
-  role_id         = "${var.role_id}"
-  organisation_id = "${var.organisation_id}"
-  record_type     = "${element(var.records, count.index)}"
-  action          = "REJECT_APPROVE"
   count           = "${length(var.records)}"
   lifecycle {
     ignore_changes = ["ace_id"]

--- a/examples/ace/read-approve/main.tf
+++ b/examples/ace/read-approve/main.tf
@@ -9,15 +9,3 @@ resource "form3_ace" "ace-read" {
     ignore_changes = ["ace_id"]
   }
 }
-
-resource "form3_ace" "ace-read-approve" {
-  ace_id          = "${uuid()}"
-  role_id         = "${var.role_id}"
-  organisation_id = "${var.organisation_id}"
-  record_type     = "${element(var.records, count.index)}"
-  action          = "APPROVE"
-  count           = "${length(var.records)}"
-  lifecycle {
-    ignore_changes = ["ace_id"]
-  }
-}


### PR DESCRIPTION
As part of the Multiple Production Stacks project we are are cleaning up the
usage of _APPROVE aces. _APPROVE aces are legacy (part of the deprecated Approve
API), and should no longer be used in order to configure permissions for roles.

Ref. https://github.com/form3tech/infrastructure/issues/2421