### PR TITLE
Use reachable_bic instead of reachable_bics in sepact-liquidity associations

### DIFF
--- a/form3/resource_sepact_liquidity_association.go
+++ b/form3/resource_sepact_liquidity_association.go
@@ -33,11 +33,8 @@ func resourceForm3SepactLiquidityAssociation() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"reachable_bics": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+			"reachable_bic": {
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -129,7 +126,7 @@ func resourceSepactLiquidityAssociationRead(d *schema.ResourceData, meta interfa
 	if err := d.Set("name", association.Payload.Data.Attributes.Name); err != nil {
 		return err
 	}
-	if err := d.Set("reachable_bics", association.Payload.Data.Attributes.ReachableBics); err != nil {
+	if err := d.Set("reachable_bic", association.Payload.Data.Attributes.ReachableBic); err != nil {
 		return err
 	}
 	if err := d.Set("settlement_bic", association.Payload.Data.Attributes.SettlementBic); err != nil {
@@ -197,11 +194,8 @@ func createSepactLiquidityNewAssociationFromResourceData(d *schema.ResourceData)
 		association.Attributes.Name = attr.(string)
 	}
 
-	if attr, ok := d.GetOk("reachable_bics"); ok {
-		arr := attr.(*schema.Set).List()
-		for _, v := range arr {
-			association.Attributes.ReachableBics = append(association.Attributes.ReachableBics, models.Bic11(v.(string)))
-		}
+	if attr, ok := d.GetOk("reachable_bic"); ok {
+		association.Attributes.ReachableBic = models.Bic11(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("settlement_bic"); ok {

--- a/form3/resource_sepact_liquidity_association_test.go
+++ b/form3/resource_sepact_liquidity_association_test.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"testing"
 
-	form3 "github.com/form3tech-oss/terraform-provider-form3/api"
-	"github.com/form3tech-oss/terraform-provider-form3/client/associations"
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	form3 "github.com/form3tech-oss/terraform-provider-form3/api"
+	"github.com/form3tech-oss/terraform-provider-form3/client/associations"
 )
 
 func TestAccSepactLiquidityAssociation_basic(t *testing.T) {
@@ -68,8 +69,7 @@ func TestAccSepactLiquidityAssociation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(indirectParticipant.path, "association_id", indirectParticipant.associationId),
 					resource.TestCheckResourceAttr(indirectParticipant.path, "organisation_id", indirectParticipant.organisationId),
 					resource.TestCheckResourceAttr(indirectParticipant.path, "name", "Indirect Participant"),
-					resource.TestCheckResourceAttr(indirectParticipant.path, "reachable_bics.#", "1"),
-					resource.TestCheckResourceAttr(indirectParticipant.path, "reachable_bics.4060745130", reachableBic),
+					resource.TestCheckResourceAttr(indirectParticipant.path, "reachable_bic", reachableBic),
 					resource.TestCheckResourceAttr(indirectParticipant.path, "settlement_bic", indirectParticipant.bic),
 					resource.TestCheckResourceAttr(indirectParticipant.path, "settlement_iban", indirectParticipant.iban),
 					resource.TestCheckResourceAttr(indirectParticipant.path, "address_street", "Harp Ln"),
@@ -176,7 +176,7 @@ resource "form3_sepact_liquidity_association" "indirect_participant_association"
 	organisation_id         = "${form3_organisation.indirect_participant.organisation_id}"
 	association_id          = "${local.indirect_participant_association_id}"
 	name                    = "Indirect Participant"
-    reachable_bics          = [ "${local.reachable_bic}" ]
+    reachable_bic           = "${local.reachable_bic}"
     settlement_bic          = "${local.indirect_participant_bic}"
     settlement_iban         = "${local.indirect_participant_iban}"
 	address_street          = "Harp Ln"

--- a/form3/resource_sepasct_association_test.go
+++ b/form3/resource_sepasct_association_test.go
@@ -58,7 +58,7 @@ func TestAccSepaSctAssociation_reachable(t *testing.T) {
 	config := fmt.Sprintf(
 		testForm3SepaSctSponsoredAssociationConfig,
 		sponsorOrganisationId, parentOrganisationId, sponsorAssociationId, sponsorBic,
-		sponsoredOrganisationId, parentOrganisationId, sponsoredAssociationId, strings.Join(sponsoredBicList, "\",\""), sponsorAssociationId,
+		sponsoredOrganisationId, parentOrganisationId, sponsoredAssociationId, strings.Join(sponsoredBicList, "\",\""),
 	)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -181,10 +181,6 @@ resource "form3_sepasct_association" "sponsored_association" {
 	organisation_id        = "${form3_organisation.sponsored_organisation.organisation_id}"
 	association_id         = "%s"
 	reachable_bics         = ["%s"]
-	sponsor_id             = "%s"
-
-	depends_on = [
-      "form3_sepasct_association.sponsor_association"
-	]
+	sponsor_id             = "${form3_sepasct_association.sponsor_association.association_id}"
 }`
 )

--- a/models/sepact_liquidity_association_attributes.go
+++ b/models/sepact_liquidity_association_attributes.go
@@ -6,8 +6,6 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"strconv"
-
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -28,8 +26,8 @@ type SepactLiquidityAssociationAttributes struct {
 	// Min Length: 1
 	Name string `json:"name"`
 
-	// List of Reachable BICs
-	ReachableBics []Bic11 `json:"reachable_bics"`
+	// reachable bic
+	ReachableBic Bic11 `json:"reachable_bic,omitempty"`
 
 	// settlement bic
 	// Required: true
@@ -52,7 +50,7 @@ func (m *SepactLiquidityAssociationAttributes) Validate(formats strfmt.Registry)
 		res = append(res, err)
 	}
 
-	if err := m.validateReachableBics(formats); err != nil {
+	if err := m.validateReachableBic(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -95,21 +93,17 @@ func (m *SepactLiquidityAssociationAttributes) validateName(formats strfmt.Regis
 	return nil
 }
 
-func (m *SepactLiquidityAssociationAttributes) validateReachableBics(formats strfmt.Registry) error {
+func (m *SepactLiquidityAssociationAttributes) validateReachableBic(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.ReachableBics) { // not required
+	if swag.IsZero(m.ReachableBic) { // not required
 		return nil
 	}
 
-	for i := 0; i < len(m.ReachableBics); i++ {
-
-		if err := m.ReachableBics[i].Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("reachable_bics" + "." + strconv.Itoa(i))
-			}
-			return err
+	if err := m.ReachableBic.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("reachable_bic")
 		}
-
+		return err
 	}
 
 	return nil

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -13313,15 +13313,8 @@ definitions:
         minLength: 1
         description: "Customer Name"
         example: "Form3 Customer"
-      reachable_bics:
-        x-nullable: true
-        x-omitempty: false
-        type: array
-        description: "List of Reachable BICs"
-        example:
-          - VTSSGB2LXXX
-        items:
-          $ref: '#/definitions/Bic11'
+      reachable_bic:
+        $ref: '#/definitions/Bic11'
       settlement_bic:
         $ref: '#/definitions/Bic8'
       settlement_iban:


### PR DESCRIPTION
See https://github.com/form3tech/indirect-team/issues/302

An organisation should be allowed to have several associations, one per reachable BIC