### PR TITLE
make it obvious where test organisations have come from

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -12,7 +12,7 @@ provider "form3" {
 resource "form3_organisation" "organisation" {
   organisation_id        = "2b7b602f-01ff-4845-892a-5a7c185867c6"
   parent_organisation_id = "${var.organisation_id}"
-  name                   = "terraform-organisation"
+  name                   = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_user" "admin_user" {

--- a/form3/resource_account_configuration_test.go
+++ b/form3/resource_account_configuration_test.go
@@ -158,7 +158,7 @@ const testForm3AccountConfigurationConfig = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_account_configuration" "configuration" {
@@ -178,7 +178,7 @@ const testForm3AccountConfigurationConfigUpdated = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_account_configuration" "configuration" {

--- a/form3/resource_account_routing_test.go
+++ b/form3/resource_account_routing_test.go
@@ -126,7 +126,7 @@ const testForm3AccountRoutingConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_account_routing" "account_routing" {

--- a/form3/resource_account_test.go
+++ b/form3/resource_account_test.go
@@ -239,7 +239,7 @@ const testForm3AccountConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_account_configuration" "customer_backoffice_configuration" {
@@ -282,7 +282,7 @@ const testForm3AccountConfigWithIban = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_account" "account" {
@@ -316,7 +316,7 @@ const testForm3AccountConfigWithIbanWithoutAccountNumber = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_account_configuration" "customer_backoffice_configuration" {

--- a/form3/resource_bacs_association_test.go
+++ b/form3/resource_bacs_association_test.go
@@ -258,7 +258,7 @@ func makeTestForm3BacsAssociationConfigWithCerts(data associationConfigWithCerts
 resource "form3_organisation" "organisation" {
 	organisation_id        = "{{ .OrgID }}"
 	parent_organisation_id = "{{ .OrgParentID }}"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_key" "inputKey" {
@@ -318,7 +318,7 @@ const testForm3BacsAssociationConfigZeroAccountType = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_bacs_association" "association" {
@@ -334,7 +334,7 @@ const testForm3BacsAssociationConfigWithBankIdAndCentre = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_bacs_association" "association" {
@@ -352,7 +352,7 @@ const testForm3BacsAssociationConfigWithTestFileFlag = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_bacs_association" "association" {
@@ -371,7 +371,7 @@ const testForm3BacsAssociationWithSunConfig = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_bacs_association" "association" {

--- a/form3/resource_bank_id_test.go
+++ b/form3/resource_bank_id_test.go
@@ -119,7 +119,7 @@ const testForm3BankIDConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_bank_id" "bank_id" {

--- a/form3/resource_certificate_test.go
+++ b/form3/resource_certificate_test.go
@@ -154,7 +154,7 @@ func TestAccKey_importExistingCert(t *testing.T) {
 				ID:             strfmt.UUID(organisationId),
 				Type:           "organisations",
 				Attributes: &models.OrganisationAttributes{
-					Name: "terraform-organisation",
+					Name: "terraform-provider-form3-test-organisation",
 				},
 			}}))
 		if err != nil {
@@ -312,7 +312,7 @@ const testForm3KeyConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_key" "test_key" {
@@ -332,7 +332,7 @@ const testForm3KeyConfigElliptic = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_key" "test_key" {
@@ -353,7 +353,7 @@ const testForm3KeyConfigWithCert = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_key" "test_key" {
@@ -378,7 +378,7 @@ const testForm3KeyConfigWithSelfSignedCert = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_key" "test_key" {
@@ -398,7 +398,7 @@ const testForm3KeyConfigExistingKey = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_key" "test_key" {

--- a/form3/resource_confirmation_of_payee_association_test.go
+++ b/form3/resource_confirmation_of_payee_association_test.go
@@ -95,7 +95,7 @@ const testForm3ConfirmationOfPayeeAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_confirmation_of_payee_association" "association" {

--- a/form3/resource_gocardless_gateway_association_test.go
+++ b/form3/resource_gocardless_gateway_association_test.go
@@ -99,7 +99,7 @@ const testForm3GocardlessAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_gocardless_association" "association" {
@@ -112,7 +112,7 @@ const testForm3GocardlessAssociationConfigB = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_gocardless_association" "association" {

--- a/form3/resource_lhv_agency_synchronisation_test.go
+++ b/form3/resource_lhv_agency_synchronisation_test.go
@@ -117,7 +117,7 @@ func lhvAgencySynchronisationConfig(data lhvAgencySynchronisationConfigData) str
 resource "form3_organisation" "organisation" {
 	organisation_id        = "{{ .OrganisationID }}"
 	parent_organisation_id = "{{ .ParentOrganisationID }}"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_lhv_association" "association" {

--- a/form3/resource_lhv_association_test.go
+++ b/form3/resource_lhv_association_test.go
@@ -95,7 +95,7 @@ const testForm3LhvAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		              = "terraform-organisation"
+	name 		              = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_lhv_association" "association" {

--- a/form3/resource_lhv_master_account_test.go
+++ b/form3/resource_lhv_master_account_test.go
@@ -116,7 +116,7 @@ locals {
 resource "form3_organisation" "organisation" {
 	organisation_id        = "${local.organisationId}"
 	parent_organisation_id = "${local.parentId}"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_lhv_association" "association" {

--- a/form3/resource_limit_test.go
+++ b/form3/resource_limit_test.go
@@ -141,7 +141,7 @@ const testForm3LimitConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_limit" "limit" {

--- a/form3/resource_limit_test.go
+++ b/form3/resource_limit_test.go
@@ -121,7 +121,6 @@ func testAccCheckLimitExists(resourceKey string, limit *limits.GetLimitsIDOK) re
 		client := testAccProvider.Meta().(*form3.AuthenticatedClient)
 
 		foundRecord, err := client.LimitsClient.Limits.GetLimitsID(limits.NewGetLimitsIDParams().WithID(strfmt.UUID(rs.Primary.ID)))
-
 		if err != nil {
 			return err
 		}
@@ -158,7 +157,7 @@ const testForm3LimitConfigExternal = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_limit" "limit" {

--- a/form3/resource_organisation_test.go
+++ b/form3/resource_organisation_test.go
@@ -28,7 +28,7 @@ func TestAccOrganisation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrganisationExists("form3_organisation.organisation", &organisationResponse),
 					resource.TestCheckResourceAttr(
-						"form3_organisation.organisation", "name", "terraform-organisation"),
+						"form3_organisation.organisation", "name", "terraform-provider-form3-test-organisation"),
 					resource.TestCheckResourceAttr(
 						"form3_organisation.organisation", "parent_organisation_id", parentOrganisationId),
 					resource.TestCheckResourceAttr(
@@ -40,7 +40,7 @@ func TestAccOrganisation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrganisationExists("form3_organisation.organisation", &organisationResponse),
 					resource.TestCheckResourceAttr(
-						"form3_organisation.organisation", "name", "terraform-organisation-updated"),
+						"form3_organisation.organisation", "name", "terraform-provider-form3-test-organisation-updated"),
 					resource.TestCheckResourceAttr(
 						"form3_organisation.organisation", "parent_organisation_id", parentOrganisationId),
 					resource.TestCheckResourceAttr(
@@ -130,12 +130,12 @@ const testForm3OrganisationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }`
 
 const testForm3OrganisationConfigAUpdate = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation-updated"
+	name 		               = "terraform-provider-form3-test-organisation-updated"
 }`

--- a/form3/resource_payment_defaults_test.go
+++ b/form3/resource_payment_defaults_test.go
@@ -91,7 +91,7 @@ const testForm3PaymentDefaultsConfig = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_payment_defaults" "payment_defaults" {

--- a/form3/resource_payport_association_test.go
+++ b/form3/resource_payport_association_test.go
@@ -172,7 +172,7 @@ const testForm3PayportAssociationConfigNonSettling = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_payport_association" "association" {
@@ -189,7 +189,7 @@ const testForm3PayportAssociationConfigSettling = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_payport_association" "association" {

--- a/form3/resource_products_association_test.go
+++ b/form3/resource_products_association_test.go
@@ -89,7 +89,7 @@ const testForm3ProductsAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 resource "form3_products_association" "association" {
 	organisation_id        = "${form3_organisation.organisation.organisation_id}"

--- a/form3/resource_reconciliation_association_test.go
+++ b/form3/resource_reconciliation_association_test.go
@@ -99,7 +99,7 @@ const testForm3ReconciliationAssociationConfig = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_reconciliation_association" "association" {

--- a/form3/resource_sepadd_association_test.go
+++ b/form3/resource_sepadd_association_test.go
@@ -93,7 +93,7 @@ const testForm3SepaDDAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepadd_association" "association" {

--- a/form3/resource_sepainstant_association_test.go
+++ b/form3/resource_sepainstant_association_test.go
@@ -132,7 +132,7 @@ locals {
 resource "form3_organisation" "organisation" {
 	organisation_id        = "${local.organisation_id}"
 	parent_organisation_id = "${local.parent_organisation_id}"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepainstant_association" "association" {
@@ -147,7 +147,7 @@ resource "form3_sepainstant_association" "association" {
 resource "form3_organisation" "organisation_sponsored" {
 	organisation_id        = "${local.organisation_sponsor_id}"
 	parent_organisation_id = "${local.parent_organisation_id}"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepainstant_association" "association_sponsored" {
@@ -177,7 +177,7 @@ locals {
 resource "form3_organisation" "organisation" {
 	organisation_id        = "${local.organisation_id}"
 	parent_organisation_id = "${local.parent_organisation_id}"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepainstant_association" "association" {

--- a/form3/resource_sepasct_association_test.go
+++ b/form3/resource_sepasct_association_test.go
@@ -145,7 +145,7 @@ const (
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepasct_association" "association" {
@@ -159,7 +159,7 @@ resource "form3_sepasct_association" "association" {
 resource "form3_organisation" "sponsor_organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepasct_association" "sponsor_association" {
@@ -174,7 +174,7 @@ resource "form3_sepasct_association" "sponsor_association" {
 resource "form3_organisation" "sponsored_organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		           = "terraform-organisation"
+	name 		           = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepasct_association" "sponsored_association" {

--- a/form3/resource_starling_association_test.go
+++ b/form3/resource_starling_association_test.go
@@ -92,7 +92,7 @@ const testForm3StarlingAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "${uuid()}"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 
   lifecycle {
     ignore_changes = ["organisation_id"]

--- a/form3/resource_vocalink_report_association_test.go
+++ b/form3/resource_vocalink_report_association_test.go
@@ -97,7 +97,7 @@ const testForm3VocalinkReportAssociationConfigA = `
 resource "form3_organisation" "organisation" {
 	organisation_id        = "%s"
 	parent_organisation_id = "%s"
-	name 		               = "terraform-organisation"
+	name 		               = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_vocalink_report_association" "association" {

--- a/form3/test.tf
+++ b/form3/test.tf
@@ -8,7 +8,7 @@ locals {
 resource "form3_organisation" "organisation" {
   organisation_id        = "${local.organisation_id}"
   parent_organisation_id = "${local.parent_organisation_id}"
-  name                   = "terraform-organisation"
+  name                   = "terraform-provider-form3-test-organisation"
 }
 
 resource "form3_sepainstant_association" "association" {


### PR DESCRIPTION
`terraform-organisation` helps, but this should make it much more obvious that this repository is the source of these test organisations.