### PR TITLE
Align sepa instant patchable attributes with gateway

### DIFF
--- a/form3/resource_sepainstant_association.go
+++ b/form3/resource_sepainstant_association.go
@@ -180,7 +180,12 @@ func resourceSepaInstantAssociationUpdate(d *schema.ResourceData, meta interface
 				OrganisationID: association.OrganisationID,
 				Type:           models.SepaInstantAssociationReferenceTypeSepainstantAssociations,
 				Attributes: &models.UpdateSepaInstantAssociationAttributes{
+					Bic:                     association.Attributes.Bic,
+					TransportProfileID:      association.Attributes.TransportProfileID,
+					BusinessUserDn:          association.Attributes.BusinessUserDn,
 					DisableOutboundPayments: association.Attributes.DisableOutboundPayments,
+					SimulatorOnly:           association.Attributes.SimulatorOnly,
+					ReachableBics:           association.Attributes.ReachableBics,
 				},
 			},
 		}))
@@ -204,9 +209,26 @@ func createSepaInstantUpdateAssociationFromResourceData(d *schema.ResourceData) 
 		association.OrganisationID = attr
 	}
 
+	if attr, ok := d.GetOk("bic"); ok {
+		association.Attributes.Bic = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("business_user_dn"); ok {
+		association.Attributes.BusinessUserDn = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("transport_profile_id"); ok {
+		association.Attributes.TransportProfileID = attr.(string)
+	}
+
 	if attr, ok := d.GetOk("disable_outbound_payments"); ok {
 		b := attr.(bool)
 		association.Attributes.DisableOutboundPayments = &b
+	}
+
+	if attr, ok := d.GetOk("simulator_only"); ok {
+		b := attr.(bool)
+		association.Attributes.SimulatorOnly = &b
 	}
 
 	if attr, ok := d.GetOk("reachable_bics"); ok {

--- a/form3/resource_sepainstant_association_test.go
+++ b/form3/resource_sepainstant_association_test.go
@@ -26,10 +26,11 @@ func TestAccSepaInstantAssociation_basic(t *testing.T) {
 	defer verifyOrgDoesNotExist(t, sponsoredOrganisationId)
 
 	bic := generateTestBic()
-	bicCN := strings.ToLower(bic)
+	bic2 := generateTestBic()
 	bicSponsored := generateTestBic()
 	reachableBics := []string{generateTestBicWithLength(11)}
-	businessUserDN := fmt.Sprintf("cn=%s,ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu", bicCN)
+	businessUserDN := fmt.Sprintf("cn=%s,ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu", strings.ToLower(bic))
+	businessUserDN2 := fmt.Sprintf("cn=%s,ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu", strings.ToLower(bic2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +41,7 @@ func TestAccSepaInstantAssociation_basic(t *testing.T) {
 				Config: fmt.Sprintf(testForm3SepaInstantAssociationConfigA,
 					organisationId, parentOrganisationId, testOrgName, associationId,
 					sponsoredOrganisationId, sponsoredAssociationId,
-					bicCN, bic, bicSponsored, strings.Join(reachableBics, "\",\"")),
+					bic, bicSponsored, strings.Join(reachableBics, "\",\"")),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSepaInstantAssociationExists("form3_sepainstant_association.association"),
 					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "association_id", associationId),
@@ -61,14 +62,14 @@ func TestAccSepaInstantAssociation_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testForm3SepaInstantAssociationUpdatedConfig, organisationId, parentOrganisationId, testOrgName, associationId, bicCN, bic),
+				Config: fmt.Sprintf(testForm3SepaInstantAssociationUpdatedConfig, organisationId, parentOrganisationId, testOrgName, associationId, bic2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSepaInstantAssociationExists("form3_sepainstant_association.association"),
 					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "association_id", associationId),
 					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "organisation_id", organisationId),
-					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "business_user_dn", businessUserDN),
-					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "transport_profile_id", "TEST_PROFILE_1"),
-					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "bic", bic),
+					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "business_user_dn", businessUserDN2),
+					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "transport_profile_id", "TEST_PROFILE_2"),
+					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "bic", bic2),
 					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "simulator_only", "true"),
 					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "disable_outbound_payments", "true"),
 					resource.TestCheckResourceAttr("form3_sepainstant_association.association", "sponsor_id", ""),
@@ -134,7 +135,6 @@ locals {
 	association_id           = "%s"
 	organisation_sponsor_id  = "%s"
 	sponsored_association_id = "%s"
-	bic_cn					 = "%s"
 	bic					     = "%s"
 	bic_sponsored			 = "%s"
     reachable_bics           = ["%s"]
@@ -149,7 +149,7 @@ resource "form3_organisation" "organisation" {
 resource "form3_sepainstant_association" "association" {
 	organisation_id      = "${form3_organisation.organisation.organisation_id}"
 	association_id       = "${local.association_id}"
-  	business_user_dn     = "cn=${local.bic_cn},ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu"
+  	business_user_dn     = "cn=${lower(local.bic)},ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu"
   	transport_profile_id = "TEST_PROFILE_1"
 	bic                  = "${local.bic}"
 	simulator_only       = true
@@ -183,7 +183,6 @@ locals {
 	parent_organisation_id   = "%s"
 	organisation_name 		 = "%s"
 	association_id           = "%s"
-	bic_cn					 = "%s"
 	bic						 = "%s"
 }
 
@@ -196,8 +195,8 @@ resource "form3_organisation" "organisation" {
 resource "form3_sepainstant_association" "association" {
 	organisation_id           = "${form3_organisation.organisation.organisation_id}"
 	association_id            = "${local.association_id}"
-  	business_user_dn          = "cn=${local.bic_cn},ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu"
-  	transport_profile_id      = "TEST_PROFILE_1"
+  	business_user_dn          = "cn=${lower(local.bic)},ou=pilot,ou=eba_ips,o=88331,dc=sianet,dc=sia,dc=eu"
+  	transport_profile_id      = "TEST_PROFILE_2"
 	bic                       = "${local.bic}"
 	simulator_only            = true
 	disable_outbound_payments = true

--- a/models/update_sepa_instant_association_attributes.go
+++ b/models/update_sepa_instant_association_attributes.go
@@ -15,11 +15,23 @@ import (
 // swagger:model UpdateSepaInstantAssociationAttributes
 type UpdateSepaInstantAssociationAttributes struct {
 
+	// bic
+	Bic string `json:"bic,omitempty"`
+
+	// business user dn
+	BusinessUserDn string `json:"business_user_dn,omitempty"`
+
 	// disable outbound payments
 	DisableOutboundPayments *bool `json:"disable_outbound_payments,omitempty"`
 
 	// reachable bics
 	ReachableBics []string `json:"reachable_bics"`
+
+	// simulator only
+	SimulatorOnly *bool `json:"simulator_only,omitempty"`
+
+	// transport profile id
+	TransportProfileID string `json:"transport_profile_id,omitempty"`
 }
 
 // Validate validates this update sepa instant association attributes

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8789,6 +8789,15 @@ definitions:
 
   UpdateSepaInstantAssociationAttributes:
     properties:
+      business_user_dn:
+        type: string
+      transport_profile_id:
+        type: string
+      bic:
+        type: string
+      simulator_only:
+        x-nullable: true
+        type: boolean
       disable_outbound_payments:
         x-nullable: true
         type: boolean


### PR DESCRIPTION
Fix issue with attributes marked as patchable and not being sent in the request, resulting in a 400 with the payload: 

```
{"error":"nothing to patch"}
```