### PR TITLE
verify fingerprint of the request signing public key

### DIFF
--- a/form3/resource_credential_public_key_test.go
+++ b/form3/resource_credential_public_key_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"testing"
 
 	form3 "github.com/form3tech-oss/terraform-provider-form3/api"
@@ -111,6 +112,7 @@ func TestAccCredentialPublicKey_fingerprint(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Given I have created an user
 			// When i add public key to this user
+			// AND this key fingerprint is valid
 			// Then I can see a public key was added
 			{
 				Config: fmt.Sprintf(testForm3CredentialPublicKeyValidFingerprint, organisationID, roleID, organisationID, userID, publicKeyID),
@@ -135,11 +137,11 @@ func TestAccCredentialPublicKey_fingerprint_invalid(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Given I have created an user
 			// When i add public key to this user
-			// Then I can see a public key was added
+			// AND this key fingerprint is invalid
+			// Then I should an error message and key should be added to state
 			{
 				Config: fmt.Sprintf(testForm3CredentialPublicKeyInValidFingerprint, organisationID, roleID, organisationID, userID, publicKeyID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCredentialPublicKeysExists([]string{"form3_credential_public_key.test_public_key_single"}, []string{publicKeyID})),
+				ExpectError: regexp.MustCompile("the provided key doesn't match the fingerprint expected: 'bb:71:0e:71:15:d1:08:0b:bd:96:fa:d9:ff:e8:a6:d3' got: '45:ec:75:7f:08:b9:7a:9a:da:59:04:94:53:9b:f9:08"),
 			},
 		},
 	})
@@ -158,11 +160,11 @@ func TestAccCredentialPublicKey_invalid_key(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Given I have created an user
 			// When i add public key to this user
-			// Then I can see a public key was added
+			// AND this key is malformed
+			// Then I should an error message
 			{
 				Config: fmt.Sprintf(testForm3CredentialPublicKeyInValidKey, organisationID, roleID, organisationID, userID, publicKeyID),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCredentialPublicKeysExists([]string{"form3_credential_public_key.test_public_key_single"}, []string{publicKeyID})),
+				ExpectError: regexp.MustCompile("the provided key is malformed and couldnt be parsed"),
 			},
 		},
 	})
@@ -365,5 +367,4 @@ resource "form3_credential_public_key" "test_public_key_single" {
 	organisation_id        = "${form3_user.public_key_test_user.organisation_id}"
 	public_key_id          = "%s"
 	public_key             = "-----BEGIN PUBLIC KEY----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4JNqRbybmYHd9jlnbQwu\nw8Rg1O21IC9bns9oeeah5ZU605taCfSJUk/sEd1IKS/n4mqIi8Pm8JLiumvh1sK3\nxnqqPhxGiLLiUt9dnK3xT2WU9YEzlxRY4BbMJV12cAKI4Fu26OKrPfumud0yQLX8\nHEQSBldq0tE9tFxZi7ruzMVP7J0cNRdPtM2F97dFMeLIyh2MzXz5vIzsKprh7jaQ\nUCC2YTrpU+ZKbpvGN5Ql3KTJroiirtqQT/ZxUzLB4ChMfOLkbKTofieeNnsU2hSV\nb1Okcv5i26rzrKW2jjrIhi/QU0R/YLEc5+A06fc9Ua9U9uqyWadHkMso6xszY2Za\nEwIDAQAB\n-----END PUBLIC KEY-----\n"
-    public_key_fingerprint = "bb:7a:0e:71:15:d1:08:0b:bd:96:fa:d9:ff:e8:a6:d3"
 }`

--- a/form3/resource_credential_public_key_test.go
+++ b/form3/resource_credential_public_key_test.go
@@ -140,7 +140,7 @@ func TestAccCredentialPublicKey_fingerprint_invalid(t *testing.T) {
 			// AND this key fingerprint is invalid
 			// Then I should an error message and key should be added to state
 			{
-				Config: fmt.Sprintf(testForm3CredentialPublicKeyInValidFingerprint, organisationID, roleID, organisationID, userID, publicKeyID),
+				Config:      fmt.Sprintf(testForm3CredentialPublicKeyInValidFingerprint, organisationID, roleID, organisationID, userID, publicKeyID),
 				ExpectError: regexp.MustCompile("the provided key doesn't match the fingerprint expected: 'bb:71:0e:71:15:d1:08:0b:bd:96:fa:d9:ff:e8:a6:d3' got: '45:ec:75:7f:08:b9:7a:9a:da:59:04:94:53:9b:f9:08"),
 			},
 		},
@@ -163,7 +163,7 @@ func TestAccCredentialPublicKey_invalid_key(t *testing.T) {
 			// AND this key is malformed
 			// Then I should an error message
 			{
-				Config: fmt.Sprintf(testForm3CredentialPublicKeyInValidKey, organisationID, roleID, organisationID, userID, publicKeyID),
+				Config:      fmt.Sprintf(testForm3CredentialPublicKeyInValidKey, organisationID, roleID, organisationID, userID, publicKeyID),
 				ExpectError: regexp.MustCompile("the provided key is malformed and couldnt be parsed"),
 			},
 		},

--- a/form3/resource_credential_public_key_test.go
+++ b/form3/resource_credential_public_key_test.go
@@ -97,6 +97,77 @@ func TestAccCredentialPublicKey_import(t *testing.T) {
 	})
 }
 
+func TestAccCredentialPublicKey_fingerprint(t *testing.T) {
+	log.SetOutput(os.Stdout)
+	organisationID := os.Getenv("FORM3_ORGANISATION_ID")
+	publicKeyID := uuid.New().String()
+	userID := uuid.New().String()
+	roleID := uuid.New().String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCredentialPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			// Given I have created an user
+			// When i add public key to this user
+			// Then I can see a public key was added
+			{
+				Config: fmt.Sprintf(testForm3CredentialPublicKeyValidFingerprint, organisationID, roleID, organisationID, userID, publicKeyID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCredentialPublicKeysExists([]string{"form3_credential_public_key.test_public_key_single"}, []string{publicKeyID})),
+			},
+		},
+	})
+}
+
+func TestAccCredentialPublicKey_fingerprint_invalid(t *testing.T) {
+	log.SetOutput(os.Stdout)
+	organisationID := os.Getenv("FORM3_ORGANISATION_ID")
+	publicKeyID := uuid.New().String()
+	userID := uuid.New().String()
+	roleID := uuid.New().String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCredentialPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			// Given I have created an user
+			// When i add public key to this user
+			// Then I can see a public key was added
+			{
+				Config: fmt.Sprintf(testForm3CredentialPublicKeyInValidFingerprint, organisationID, roleID, organisationID, userID, publicKeyID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCredentialPublicKeysExists([]string{"form3_credential_public_key.test_public_key_single"}, []string{publicKeyID})),
+			},
+		},
+	})
+}
+func TestAccCredentialPublicKey_invalid_key(t *testing.T) {
+	log.SetOutput(os.Stdout)
+	organisationID := os.Getenv("FORM3_ORGANISATION_ID")
+	publicKeyID := uuid.New().String()
+	userID := uuid.New().String()
+	roleID := uuid.New().String()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCredentialPublicKeyDestroy,
+		Steps: []resource.TestStep{
+			// Given I have created an user
+			// When i add public key to this user
+			// Then I can see a public key was added
+			{
+				Config: fmt.Sprintf(testForm3CredentialPublicKeyInValidKey, organisationID, roleID, organisationID, userID, publicKeyID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCredentialPublicKeysExists([]string{"form3_credential_public_key.test_public_key_single"}, []string{publicKeyID})),
+			},
+		},
+	})
+}
+
 func testAccCheckCredentialPublicKeyDestroy(state *terraform.State) error {
 	client := testAccProvider.Meta().(*form3.AuthenticatedClient)
 
@@ -226,4 +297,73 @@ resource "form3_credential_public_key" "test_public_key_single" {
 	organisation_id = "${form3_user.public_key_test_user.organisation_id}"
 	public_key_id   = "%s"
 	public_key      = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4JNqRbybmYHd9jlnbQwu\nw8Rg1O21IC9bns9oeeah5ZU605taCfSJUk/sEd1IKS/n4mqIi8Pm8JLiumvh1sK3\nxnqqPhxGiLLiUt9dnK3xT2WU9YEzlxRY4BbMJV12cAKI4Fu26OKrPfumud0yQLX8\nHEQSBldq0tE9tFxZi7ruzMVP7J0cNRdPtM2F97dFMeLIyh2MzXz5vIzsKprh7jaQ\nUCC2YTrpU+ZKbpvGN5Ql3KTJroiirtqQT/ZxUzLB4ChMfOLkbKTofieeNnsU2hSV\nb1Okcv5i26rzrKW2jjrIhi/QU0R/YLEc5+A06fc9Ua9U9uqyWadHkMso6xszY2Za\nEwIDAQAB\n-----END PUBLIC KEY-----\n"
+}`
+
+const testForm3CredentialPublicKeyValidFingerprint = `
+resource "form3_role" "role" {
+	organisation_id = "%s"
+	role_id 		= "%s"
+	name     		= "terraform-role"
+}
+
+resource "form3_user" "public_key_test_user" {
+	organisation_id = "%s"
+	user_id 		= "%s"
+	user_name 	    = "terraform-user"
+	email 			= "terraform-user@form3.tech"
+	roles 			= ["${form3_role.role.role_id}"]
+}
+
+resource "form3_credential_public_key" "test_public_key_single" {
+	user_id 		       = "${form3_user.public_key_test_user.user_id}"
+	organisation_id        = "${form3_user.public_key_test_user.organisation_id}"
+	public_key_id          = "%s"
+	public_key             = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4JNqRbybmYHd9jlnbQwu\nw8Rg1O21IC9bns9oeeah5ZU605taCfSJUk/sEd1IKS/n4mqIi8Pm8JLiumvh1sK3\nxnqqPhxGiLLiUt9dnK3xT2WU9YEzlxRY4BbMJV12cAKI4Fu26OKrPfumud0yQLX8\nHEQSBldq0tE9tFxZi7ruzMVP7J0cNRdPtM2F97dFMeLIyh2MzXz5vIzsKprh7jaQ\nUCC2YTrpU+ZKbpvGN5Ql3KTJroiirtqQT/ZxUzLB4ChMfOLkbKTofieeNnsU2hSV\nb1Okcv5i26rzrKW2jjrIhi/QU0R/YLEc5+A06fc9Ua9U9uqyWadHkMso6xszY2Za\nEwIDAQAB\n-----END PUBLIC KEY-----\n"
+    public_key_fingerprint = "45:ec:75:7f:08:b9:7a:9a:da:59:04:94:53:9b:f9:08"
+}`
+
+const testForm3CredentialPublicKeyInValidFingerprint = `
+resource "form3_role" "role" {
+	organisation_id = "%s"
+	role_id 		= "%s"
+	name     		= "terraform-role"
+}
+
+resource "form3_user" "public_key_test_user" {
+	organisation_id = "%s"
+	user_id 		= "%s"
+	user_name 	    = "terraform-user"
+	email 			= "terraform-user@form3.tech"
+	roles 			= ["${form3_role.role.role_id}"]
+}
+
+resource "form3_credential_public_key" "test_public_key_single" {
+	user_id 		       = "${form3_user.public_key_test_user.user_id}"
+	organisation_id        = "${form3_user.public_key_test_user.organisation_id}"
+	public_key_id          = "%s"
+	public_key             = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4JNqRbybmYHd9jlnbQwu\nw8Rg1O21IC9bns9oeeah5ZU605taCfSJUk/sEd1IKS/n4mqIi8Pm8JLiumvh1sK3\nxnqqPhxGiLLiUt9dnK3xT2WU9YEzlxRY4BbMJV12cAKI4Fu26OKrPfumud0yQLX8\nHEQSBldq0tE9tFxZi7ruzMVP7J0cNRdPtM2F97dFMeLIyh2MzXz5vIzsKprh7jaQ\nUCC2YTrpU+ZKbpvGN5Ql3KTJroiirtqQT/ZxUzLB4ChMfOLkbKTofieeNnsU2hSV\nb1Okcv5i26rzrKW2jjrIhi/QU0R/YLEc5+A06fc9Ua9U9uqyWadHkMso6xszY2Za\nEwIDAQAB\n-----END PUBLIC KEY-----\n"
+    public_key_fingerprint = "bb:71:0e:71:15:d1:08:0b:bd:96:fa:d9:ff:e8:a6:d3"
+}`
+
+const testForm3CredentialPublicKeyInValidKey = `
+resource "form3_role" "role" {
+	organisation_id = "%s"
+	role_id 		= "%s"
+	name     		= "terraform-role"
+}
+
+resource "form3_user" "public_key_test_user" {
+	organisation_id = "%s"
+	user_id 		= "%s"
+	user_name 	    = "terraform-user"
+	email 			= "terraform-user@form3.tech"
+	roles 			= ["${form3_role.role.role_id}"]
+}
+
+resource "form3_credential_public_key" "test_public_key_single" {
+	user_id 		       = "${form3_user.public_key_test_user.user_id}"
+	organisation_id        = "${form3_user.public_key_test_user.organisation_id}"
+	public_key_id          = "%s"
+	public_key             = "-----BEGIN PUBLIC KEY----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4JNqRbybmYHd9jlnbQwu\nw8Rg1O21IC9bns9oeeah5ZU605taCfSJUk/sEd1IKS/n4mqIi8Pm8JLiumvh1sK3\nxnqqPhxGiLLiUt9dnK3xT2WU9YEzlxRY4BbMJV12cAKI4Fu26OKrPfumud0yQLX8\nHEQSBldq0tE9tFxZi7ruzMVP7J0cNRdPtM2F97dFMeLIyh2MzXz5vIzsKprh7jaQ\nUCC2YTrpU+ZKbpvGN5Ql3KTJroiirtqQT/ZxUzLB4ChMfOLkbKTofieeNnsU2hSV\nb1Okcv5i26rzrKW2jjrIhi/QU0R/YLEc5+A06fc9Ua9U9uqyWadHkMso6xszY2Za\nEwIDAQAB\n-----END PUBLIC KEY-----\n"
+    public_key_fingerprint = "bb:7a:0e:71:15:d1:08:0b:bd:96:fa:d9:ff:e8:a6:d3"
 }`

--- a/form3/resource_credential_publickey.go
+++ b/form3/resource_credential_publickey.go
@@ -152,7 +152,7 @@ func createCredentialPublicKeyFromResourceData(d *schema.ResourceData) (*models.
 		keyString := attr.(string)
 
 		if err := checkIfKeyIsValid(keyString); err != nil {
-			return nil, fmt.Errorf("the provided key is malformed and couldnt be parsed : %s", err);
+			return nil, fmt.Errorf("the provided key is malformed and couldnt be parsed : %s", err)
 		}
 
 		// we only want to verify fingerprint when its specified with key


### PR DESCRIPTION
### New optional attribute for key - `public_key_fingerprint`
If set - on apply the provider will verify if specified key matches the fingerprint by calculating `md5` out of `PEM` format of the 
key.
If not set the verification won't be done.

#### Example
```
resource "form3_credential_public_key" "test_public_key_single" {
	user_id                 = "45c0a0ec-8cc5-11eb-8dcd-0242ac130003"
	organisation_id         = "45c0a0ec-8cc5-11eb-8dcd-0242ac130003"
	public_key_id           = "45c0a0ec-8cc5-11eb-8dcd-0242ac130003"
	public_key              = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4JNqRbybmYHd9jlnbQwu\nw8Rg1O21IC9bns9oeeah5ZU605taCfSJUk/sEd1IKS/n4mqIi8Pm8JLiumvh1sK3\nxnqqPhxGiLLiUt9dnK3xT2WU9YEzlxRY4BbMJV12cAKI4Fu26OKrPfumud0yQLX8\nHEQSBldq0tE9tFxZi7ruzMVP7J0cNRdPtM2F97dFMeLIyh2MzXz5vIzsKprh7jaQ\nUCC2YTrpU+ZKbpvGN5Ql3KTJroiirtqQT/ZxUzLB4ChMfOLkbKTofieeNnsU2hSV\nb1Okcv5i26rzrKW2jjrIhi/QU0R/YLEc5+A06fc9Ua9U9uqyWadHkMso6xszY2Za\nEwIDAQAB\n-----END PUBLIC KEY-----\n"
        public_key_fingerprint  = "45:ec:75:7f:08:b9:7a:9a:da:59:04:94:53:9b:f9:08"
}
```

### Verify if public key is valid and not malformed
On apply the public key will be verified if its not malformed.
Had to use `recover` here as `key parsing` logic is panicking if key is malformed.